### PR TITLE
Open pickle in binary mode

### DIFF
--- a/hl7tojson/parser.py
+++ b/hl7tojson/parser.py
@@ -11,13 +11,13 @@ FILE_PATH = dirname(__file__)
 
 import pickle
 
-with open('{}/data/{}/fields.pickle'.format(FILE_PATH, HL7_VERSION)) as f:
+with open('{}/data/{}/fields.pickle'.format(FILE_PATH, HL7_VERSION), "rb") as f:
     fields = pickle.load(f)
 
-with open('{}/data/{}/messages.pickle'.format(FILE_PATH, HL7_VERSION)) as f:
+with open('{}/data/{}/messages.pickle'.format(FILE_PATH, HL7_VERSION), "rb") as f:
     messages = pickle.load(f)
 
-with open('{}/data/{}/segments.pickle'.format(FILE_PATH, HL7_VERSION)) as f:
+with open('{}/data/{}/segments.pickle'.format(FILE_PATH, HL7_VERSION), "rb") as f:
     segments = pickle.load(f)
 
 


### PR DESCRIPTION
pickle.load expects the file object to be type IO[bytes]. Open file in binary mode to pass compatible type.